### PR TITLE
Add temporary administrative widget to facilitate content review

### DIFF
--- a/custom-child-post-types.php
+++ b/custom-child-post-types.php
@@ -3,7 +3,7 @@
  * Plugin Name: MITlib Custom Child Theme Post Types
  * Plugin URI: https://github.com/MITLibraries/Custom-Child-Theme-Post-Types
  * Description: A plugin that adds custom post types for Exhibits theme
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Phillip Bruk for MIT Libraries
  * License: GPL2
  *
@@ -11,6 +11,10 @@
  * @author Phillip Bruk for MIT Libraries
  * @link https://github.com/MITLibraries/Custom-Child-Theme-Post-Types
  */
+
+require plugin_dir_path( __FILE__ ) . 'src/class-integritywidget.php';
+
+add_action( 'wp_dashboard_setup', array( 'IntegrityWidget', 'init' ) );
 
 if ( ! function_exists( 'exhibit_post_type' ) ) {
 	/**

--- a/src/class-integritywidget.php
+++ b/src/class-integritywidget.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Class that defines a dashboard widget.
+ *
+ * @package Custom Child Theme Post types
+ * @since 1.1.0
+ */
+
+/**
+ * Defines base widget
+ */
+class IntegrityWidget {
+
+	/**
+	 * The id of this widget.
+	 */
+	const WID = 'exhibit_integrity';
+
+	/**
+	 * The required permission to access this page.
+	 */
+	const PERMS = 'manage_options';
+
+	/**
+	 * Hook to wp_dashboard_setup to add the widget.
+	 */
+	public static function init() {
+
+		// Define the dashboard widget.
+		if ( current_user_can( self::PERMS ) ) {
+			wp_add_dashboard_widget(
+				self::WID, // A unique slug/ID.
+				'Exhibit data integrity', // Visible name for the widget.
+				array( 'IntegrityWidget', 'widget' )  // Callback for the main widget content.
+			);
+		}
+	}
+
+	/**
+	 * Load the widget code
+	 */
+	public static function widget() {
+
+		// Check user capabilities.
+		if ( ! current_user_can( self::PERMS ) ) {
+			return;
+		}
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'exhibits',
+				'posts_per_page' => 99,
+			)
+		);
+
+		if ( function_exists( 'get_exhibit_location' ) ) {
+			// Use the template to render widget output.
+			require_once( plugin_dir_path( __FILE__ ) . '../templates/integrity-widget.php' );
+		} else {
+			// Use the template to render widget output.
+			require_once( plugin_dir_path( __FILE__ ) . '../templates/integrity-widget-pending.php' );
+		}
+	}
+}

--- a/templates/integrity-widget-pending.php
+++ b/templates/integrity-widget-pending.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The template for the administrative widget that confirms Exhibit data integrity.
+ *
+ * @package Custom Child Theme Post types
+ * @since 1.1.0
+ */
+
+?>
+
+<p>This widget analyzes all Exhibit records, checking for records which need
+their location adjusted while we launch the new location features.</p>
+
+<p><strong>This widget relies upon a theme function which was not found. It will
+start functioning once the expected release of the Child theme has been
+deployed.</strong></p>

--- a/templates/integrity-widget.php
+++ b/templates/integrity-widget.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * The template for the administrative widget that confirms Exhibit data integrity.
+ *
+ * @package Custom Child Theme Post types
+ * @since 1.1.0
+ */
+
+?>
+
+<p>This widget analyzes all Exhibit records, checking for records which need
+their location adjusted while we launch the new location features.</p>
+
+<p><strong>The following records may need to be edited:</strong></p>
+
+<?php
+$total = 0;
+$match = 0;
+$miss = 0;
+
+if ( $query->have_posts() ) {
+	echo '<ol>';
+	while ( $query->have_posts() ) {
+		$query->the_post();
+		$location_info = get_exhibit_location();
+
+		$acf_location = get_field( 'location' );
+		$cat_location = $location_info['name'];
+
+		if ( $acf_location === $cat_location ) {
+			++$match;
+		} else {
+			++$miss;
+			echo '<li>';
+			the_title();
+			echo '<br>';
+			echo esc_html( $acf_location ) . '<br>';
+			echo esc_html( $cat_location ) . '<br>';
+			echo '</li>';
+		}
+
+		++$total;
+	}
+	echo '</ol>';
+
+	wp_reset_postdata();
+} else {
+	esc_html( 'There are no Exhibit records to anlayze.' );
+};
+
+echo esc_html( "${total} exhibits were found" ) . '<br>';
+echo esc_html( "${match} good records" ) . '<br>';
+echo esc_html( "${miss} records have issues" ) . '<br>';
+?>


### PR DESCRIPTION
#### What does this PR do?

This creates a new dashboard widget that analyzes existing Exhibit posts, and lists those which might need to be edited during the transition between the ACF-defined Location field and the use of a Category for this information.

![Screen Shot 2022-08-23 at 2 03 38 PM](https://user-images.githubusercontent.com/1403248/186231758-a355029f-7a58-4841-9e13-063476ddf40e.png)

The widget is a temporary display, to be used only during the implementation of UXWS-1396. Once the feature is successfully in use, a new release of this plugin will remove the widget.

#### Helpful background context (if appropriate)

While this feature has not required a breaking change to the Exhibits data model, and thus we don't need to be super concerned with building a data migration, having a view of the records like this has still proved helpful in local testing.

#### How can a reviewer manually see the effects of these changes?

The widget is active on our staging site.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/UXWS-1396

#### Todo:
- [x] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?

YES - this is one of two coordinated pull requests. The other is MITLibraries/MITLibraries-child#163 , which updates the theme to anticipate the data changes that are part of this feature.

#### Requires change to deploy process?

NO
